### PR TITLE
Feature add for custom dictionaries

### DIFF
--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -839,7 +839,7 @@ export class VariousComplementsSettingTab extends PluginSettingTab {
       new Setting(containerEl)
         .setName("Custom dictionary paths")
         .setDesc(
-          "Specify either a relative path from Vault root or URL for each line."
+          "Specify either a relative path to a file or folder from the Vault root or enter a URL. Place one entry per line."
         )
         .addTextArea((tac) => {
           const el = tac

--- a/src/ui/component/CustomDictionaryWordAdd.svelte
+++ b/src/ui/component/CustomDictionaryWordAdd.svelte
@@ -28,7 +28,7 @@
 
   let aliasesStr = aliases.join("\n");
   let wordRef: HTMLElement | null = null;
-  let displayedWordRef: HTMLElement | null  = null;
+  let displayedWordRef: HTMLElement | null = null;
 
   $: enableSubmit = inputWord.length > 0;
   $: enableDisplayedWord = Boolean(dividerForDisplay);
@@ -103,7 +103,7 @@
   <h3>Description</h3>
   <input type="text" bind:value={description} style="width: 100%;" />
 
-  <h3>Aliases (for each line)</h3>
+  <h3>Aliases (one per line)</h3>
   <textarea bind:value={aliasesStr} style="width: 100%;" rows="3" />
 
   <div style="text-align: center; width: 100%; padding-top: 15px;">


### PR DESCRIPTION
It was not clear to me how to add custom dictionaries so a couple items that may be useful:

- I updated some wording for the custom dictionaries.
- I allowed dictionary directories to be used so I didn't need to manually keep adding the individual files.
- It is too hard to do anything but basic multi-line completions, so I allowed `\n` when followed by a line break to drop the line break I.E

Before: The old style needed
`|  Header 1   |  Header 2   |\n|:------------|:------------|\n|  Content 1  |  Content 2  |\n,Table,@table`

After: The alternate way to format multi-line completions
|  Header 1   |  Header 2   |\n
|:------------|:------------|\n
|  Content 1  |  Content 2  |\n
,Table,@table

Note that both these styles can be used at the same time.
